### PR TITLE
Chore: otp 인증 후 반환 데이터에 닉네임 추가

### DIFF
--- a/src/main/java/com/capstone/rentit/locker/dto/EligibleRentalsEvent.java
+++ b/src/main/java/com/capstone/rentit/locker/dto/EligibleRentalsEvent.java
@@ -9,5 +9,6 @@ public record EligibleRentalsEvent(
         Long deviceId,
         RentalLockerAction action,
         Long memberId,
+        String nickname,
         List<RentalBriefResponseForLocker> rentals
 ) implements LockerDeviceEvent { }

--- a/src/main/java/com/capstone/rentit/locker/message/LockerDeviceRequestListener.java
+++ b/src/main/java/com/capstone/rentit/locker/message/LockerDeviceRequestListener.java
@@ -86,7 +86,7 @@ public class LockerDeviceRequestListener {
                 producer.pushEligibleRentals(req.deviceId(),
                         CommonResponse.success(
                                 new EligibleRentalsEvent(req.deviceId(), req.action(),
-                                        member.getMemberId(), rentals)
+                                        member.getMemberId(), member.getNickname(), rentals)
                         ));
             } else { // "available"
                 var lockers = lockerService.findAvailableLockers(req.deviceId());

--- a/src/main/java/com/capstone/rentit/member/dto/CompanyDto.java
+++ b/src/main/java/com/capstone/rentit/member/dto/CompanyDto.java
@@ -13,6 +13,7 @@ public class CompanyDto extends MemberDto {
         return CompanyDto.builder()
                 .memberId(entity.getMemberId())
                 .name(entity.getName())
+                .nickname(entity.getNickname())
                 .email(entity.getEmail())
                 .role(entity.getRole())
                 .profileImg(presignedUrl)

--- a/src/main/java/com/capstone/rentit/member/dto/MemberDto.java
+++ b/src/main/java/com/capstone/rentit/member/dto/MemberDto.java
@@ -7,7 +7,6 @@ import com.capstone.rentit.member.domain.StudentCouncilMember;
 import com.capstone.rentit.member.exception.MemberTypeMismatchException;
 import com.capstone.rentit.member.status.MemberRoleEnum;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
@@ -18,6 +17,7 @@ public abstract class MemberDto {
     Long memberId;
     String email;
     String name;
+    String nickname;
     MemberRoleEnum role;
     String profileImg;
     LocalDate createdAt;

--- a/src/main/java/com/capstone/rentit/member/dto/StudentCouncilMemberDto.java
+++ b/src/main/java/com/capstone/rentit/member/dto/StudentCouncilMemberDto.java
@@ -13,6 +13,7 @@ public class StudentCouncilMemberDto extends MemberDto {
         return StudentCouncilMemberDto.builder()
                 .memberId(entity.getMemberId())
                 .name(entity.getName())
+                .nickname(entity.getNickname())
                 .email(entity.getEmail())
                 .role(entity.getRole())
                 .profileImg(presignedUrl)

--- a/src/main/java/com/capstone/rentit/member/dto/StudentDto.java
+++ b/src/main/java/com/capstone/rentit/member/dto/StudentDto.java
@@ -8,7 +8,6 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder
 public class StudentDto extends MemberDto {
-    private String nickname;
     private GenderEnum gender;
     private String studentId;
     private String university;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용
> otp 인증 후 반환 데이터에 닉네임 추가

## 스크린샷 (변경된 화면, 또는 postman 첨부)

## 💬리뷰 요구사항(선택)
